### PR TITLE
Remove unused maven scripting plugin

### DIFF
--- a/opencds-ice-service/pom.xml
+++ b/opencds-ice-service/pom.xml
@@ -598,6 +598,7 @@
                     </execution>
                 </executions>
             </plugin>
+            <!--
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-scripting-plugin</artifactId>
@@ -631,6 +632,7 @@
                     </dependency>
                 </dependencies>
             </plugin>
+            -->
             <plugin>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>


### PR DESCRIPTION
Removal of unused maven scripting plugin that requires the opencds-war-test project, which is unused by ICE